### PR TITLE
fix: calculate end position of carousel so it doesn't scroll too far

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -589,22 +589,22 @@ export default class Carousel extends Component {
             let animatedValue;
 
             if (this._getCustomData(props).length - 1 == index && activeSlideAlignment=='start' && !loop){
-				var offset = lastItemOffsetWidth;
-				if (offset === undefined) {
-                    offset = 0;
+		var offset = lastItemOffsetWidth;
+		if (offset === undefined) {
+                  offset = 0;
                 }
 
-				this._positions[index] = {
-					start: index * sizeRef - (sliderWidth - (sizeRef + offset)),
-					end: index * sizeRef - (sliderWidth - (sizeRef + offset)) + sizeRef
-				};
+		this._positions[index] = {
+		  start: index * sizeRef - (sliderWidth - (sizeRef + offset)),
+		  end: index * sizeRef - (sliderWidth - (sizeRef + offset)) + sizeRef
+		};
 
-			} else {
-				this._positions[index] = {
-					start: index * sizeRef,
-					end: index * sizeRef + sizeRef
-				};
-			}
+	    } else {
+		this._positions[index] = {
+		  start: index * sizeRef,
+		  end: index * sizeRef + sizeRef
+		};
+	    }
 
             if (!this._shouldAnimateSlides(props)) {
                 animatedValue = new Animated.Value(1);

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -61,6 +61,7 @@ export default class Carousel extends Component {
         loopClonesPerSide: PropTypes.number,
         scrollEnabled: PropTypes.bool,
         scrollInterpolator: PropTypes.func,
+        lastItemOffsetWidth: PropTypes.number,
         slideInterpolatedStyle: PropTypes.func,
         slideStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
         shouldOptimizeUpdates: PropTypes.bool,
@@ -573,7 +574,7 @@ export default class Carousel extends Component {
     }
 
     _initPositionsAndInterpolators (props = this.props) {
-        const { data, itemWidth, itemHeight, scrollInterpolator, vertical } = props;
+        const { data, itemWidth, itemHeight, scrollInterpolator, vertical, sliderWidth, loop, activeSlideAlignment, lastItemOffsetWidth } = props;
         const sizeRef = vertical ? itemHeight : itemWidth;
 
         if (!data || !data.length) {
@@ -587,10 +588,23 @@ export default class Carousel extends Component {
             const _index = this._getCustomIndex(index, props);
             let animatedValue;
 
-            this._positions[index] = {
-                start: index * sizeRef,
-                end: index * sizeRef + sizeRef
-            };
+            if (this._getCustomData(props).length - 1 == index && activeSlideAlignment=='start' && !loop){
+				var offset = lastItemOffsetWidth;
+				if (offset === undefined) {
+                    offset = 0;
+                }
+
+				this._positions[index] = {
+					start: index * sizeRef - (sliderWidth - (sizeRef + offset)),
+					end: index * sizeRef - (sliderWidth - (sizeRef + offset)) + sizeRef
+				};
+
+			} else {
+				this._positions[index] = {
+					start: index * sizeRef,
+					end: index * sizeRef + sizeRef
+				};
+			}
 
             if (!this._shouldAnimateSlides(props)) {
                 animatedValue = new Animated.Value(1);


### PR DESCRIPTION
https://brandingbrand.atlassian.net/browse/FCR-5782

By default in all of our feeds carousels, you can continue to swipe until it the last item is all the way to the left.  This changes the calculations so it more traditional stops scrolling once the last item is in view.  Also accepts a prop `lastItemOffsetWidth` so you can tweak that slide position further on a as-needed basis, but ive found the default 0 is usually pretty good.


https://github.com/brandingbrand/react-native-snap-carousel/assets/2859495/dea9ec2f-f886-4361-b527-fe72cba920eb




### What does this PR do?


### What testing has been done on this change?


### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [ ] Default setup ([example](https://github.com/meliorence/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [ ] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Vertical carousels ([prop `vertical`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [ ] Autoplay ([prop `autoplay`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [ ] Loop mode ([prop `loop`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [ ] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] [Callback methods](https://github.com/meliorence/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [ ] [`ParallaxImage` component](https://github.com/meliorence/react-native-snap-carousel#parallaximage-component)
- [ ] [`Pagination` component](https://github.com/meliorence/react-native-snap-carousel#pagination-component)
- [ ] [Layouts and custom interpolations](https://github.com/meliorence/react-native-snap-carousel#layouts-and-custom-interpolations)
